### PR TITLE
Update pygtail to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,11 @@ Forked from http://admin.shamot.cz/?p=424
 # Installation
     # for Ubuntu / Debian
     apt-get install pflogsumm
+    apt-get install python3-pygtail
     
     # for CentOS
     yum install postfix-perl-scripts
-    
-    cp pygtail.py /usr/sbin/
-    chmod +x /usr/sbin/pygtail.py
-    
+        
     # ! check MAILLOG path in zabbix-postfix-stats.sh
     cp zabbix-postfix-stats.sh /usr/bin/
     chmod +x /usr/bin/zabbix-postfix-stats.sh
@@ -29,6 +27,9 @@ Forked from http://admin.shamot.cz/?p=424
     Defaults:zabbix !requiretty
     zabbix ALL=(ALL) NOPASSWD: /usr/bin/zabbix-postfix-stats.sh
     
+    # Or add zabbix to the adm group to read log files: 
+    usermod -a -G adm zabbix  
+        
     systemctl restart zabbix-agent
 
 Finally import template_app_zabbix.xml and attach it to your host

--- a/zabbix-postfix-stats.sh
+++ b/zabbix-postfix-stats.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-MAILLOG=/var/log/mail.log
+MAILLOG=/var/log/maillog
 PFOFFSETFILE=/tmp/zabbix-postfix-offset.dat
 PFSTATSFILE=/tmp/postfix_statsfile.dat
 TEMPFILE=$(mktemp)
 PFLOGSUMM=/usr/sbin/pflogsumm
-PYGTAIL=/usr/sbin/pygtail.py
+PYGTAIL=/usr/lib/python3/dist-packages/pygtail/core.py
 
 # list of values we are interested in
 PFVALS=( 'received' 'delivered' 'forwarded' 'deferred' 'bounced' 'rejected' 'held' 'discarded' 'reject_warnings' 'bytes_received' 'bytes_delivered' )
@@ -24,7 +24,7 @@ if [ ! -x ${PFLOGSUMM} ] ; then
         exit 1
 fi
 
-if [ ! -x ${PYGTAIL} ] ; then
+if [ ! -r ${PYGTAIL} ] ; then
         echo "ERROR: ${PYGTAIL} not found"
         exit 1
 fi
@@ -88,7 +88,7 @@ if [ -n "$1" ]; then
         readvalue "$1"
 else
         # read the new part of mail log and read it with pflogsumm to get the summary
-        "${PYGTAIL}" -o"${PFOFFSETFILE}" "${MAILLOG}" | "${PFLOGSUMM}" -h 0 -u 0 --no_bounce_detail --no_deferral_detail --no_reject_detail --no_smtpd_warnings --no_no_msg_size > "${TEMPFILE}" 2>/dev/null
+        python3 "${PYGTAIL}" -o"${PFOFFSETFILE}" "${MAILLOG}" | "${PFLOGSUMM}" -h 0 -u 0 --no_bounce_detail --no_deferral_detail --no_reject_detail --no_smtpd_warnings --no_no_msg_size > "${TEMPFILE}" 2>/dev/null
 
         if [ ! $? -eq 0 ]; then
                 result_text="ERROR: wrong exit code returned while running  \"${PYGTAIL}\" -o\"${PFOFFSETFILE}\" \"${MAILLOG}\" | \"${PFLOGSUMM}\" -h 0 -u 0 --no_bounce_detail --no_deferral_detail --no_reject_detail --no_smtpd_warnings --no_no_msg_size > \"${TEMPFILE}\" 2>/dev/null"


### PR DESCRIPTION
Updated the dependency to support newer linux so it works out of the box on debian 12. Instead of shipping an out of date version of pygtail just use the distribution's version. I updated the install instruction for debian/ubuntu. 


